### PR TITLE
[setup.py] add explicit dep on numpy for install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import numpy
+
+#import distutils.debug
+#distutils.debug.DEBUG = 'yes'
+from setuptools import setup, Extension
+
 if sys.hexversion < 0x03000000: # uniform unicode handling for both Python 2.x and 3.x
     def u(x):
         return x.decode('utf-8')
@@ -19,17 +23,32 @@ u('''
   Copyright © 2011 Daniel Müllner
   <http://danifold.net>
 ''')
-#import distutils.debug
-#distutils.debug.DEBUG = 'yes'
-from setuptools import setup, Extension
 
 with textfileopen('fastcluster.py') as f:
     for line in f:
-        if line.find('__version_info__ =')==0:
+        if line.find('__version_info__ =') == 0:
             version = '.'.join(line.split("'")[1:-1:2])
             break
 
 print('Version: ' + version)
+
+
+def get_include_dirs():
+    """ avoid importing numpy until here, so that users can run "setup.py install"
+    without having numpy installed yet """
+    def is_special_command():
+        special_list = ('--help-commands',
+                        'egg_info',
+                        '--version',
+                        'clean')
+        return ('--help' in sys.argv[1:] or
+                sys.argv[1] in special_list)
+
+    if len(sys.argv) >= 2 and is_special_command():
+        return []
+
+    import numpy
+    return [numpy.get_include()]
 
 setup(name='fastcluster',
       version=version,
@@ -69,11 +88,13 @@ Clustering Routines for R and Python*, Journal of Statistical Software, **53**
 (2013), no. 9, 1–18, http://www.jstatsoft.org/v53/i09/.
 """),
       requires=['numpy'],
+      install_requires=["numpy>=1.9"],
+      setup_requires=['numpy'],
       provides=['fastcluster'],
       ext_modules=[Extension('_fastcluster',
                              ['src/fastcluster_python.cpp'],
-                             extra_compile_args=['/EHsc'] if os.name=='nt' else [],
-                             include_dirs=[numpy.get_include()],
+                             extra_compile_args=['/EHsc'] if os.name == 'nt' else [],
+                             include_dirs=get_include_dirs(),
 # Feel free to uncomment the line below if you use the GCC.
 # This switches to more aggressive optimization and turns
 # more warning switches on. No warning should appear in
@@ -92,23 +113,25 @@ Clustering Routines for R and Python*, Journal of Statistical Software, **53**
 # Linker optimization
 #extra_link_args=['-Wl,--strip-all'],
       )],
-      keywords=['dendrogram', 'linkage', 'cluster', 'agglomerative', 'hierarchical', 'hierarchy', 'ward'],
+      keywords=['dendrogram', 'linkage', 'cluster', 'agglomerative',
+                'hierarchical', 'hierarchy', 'ward'],
       author=u("Daniel Müllner"),
       author_email="daniel@danifold.net",
       license="BSD <http://opensource.org/licenses/BSD-2-Clause>",
-      classifiers = ["Topic :: Scientific/Engineering :: Information Analysis",
-                     "Topic :: Scientific/Engineering :: Artificial Intelligence",
-                     "Topic :: Scientific/Engineering :: Bio-Informatics",
-                     "Topic :: Scientific/Engineering :: Mathematics",
-                     "Programming Language :: Python",
-                     "Programming Language :: Python :: 2",
-                     "Programming Language :: Python :: 3",
-                     "Programming Language :: C++",
-                     "Operating System :: OS Independent",
-                     "License :: OSI Approved :: BSD License",
-                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-                     "Intended Audience :: Science/Research",
-                     "Development Status :: 5 - Production/Stable"],
-      url = 'http://danifold.net',
+      classifiers=[
+          "Topic :: Scientific/Engineering :: Information Analysis",
+          "Topic :: Scientific/Engineering :: Artificial Intelligence",
+          "Topic :: Scientific/Engineering :: Bio-Informatics",
+          "Topic :: Scientific/Engineering :: Mathematics",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: C++",
+          "Operating System :: OS Independent",
+          "License :: OSI Approved :: BSD License",
+          "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+          "Intended Audience :: Science/Research",
+          "Development Status :: 5 - Production/Stable"],
+      url='http://danifold.net',
       test_suite='tests.fastcluster_test',
 )


### PR DESCRIPTION
Currently, fastcluster cannot be installed on a machine which does not have numpy installed. 

Install fails during the initial read of setup.py, which means that pip is unable to read the dependencies listed inside setup.py. 

This PR moves the numpy dep into a helper function, which will not be executed during a `pip install fastcluster` 

The majority of this work was by @shezadkhan137

```
Collecting fastcluster (from dedupe==1.4.15->csvmatch)
  Using cached fastcluster-1.1.22.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-c4_mgn1z/fastcluster/setup.py", line 5, in <module>
        import numpy
    ImportError: No module named 'numpy'
```

Note: this replaces https://github.com/cran/fastcluster/pull/1