### PR TITLE
set numpy requirement for python 3.8 build setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ requires = ["setuptools",
             "wheel",
             "numpy==1.10.4; python_version<'3.6'",
             "numpy==1.12.1; python_version=='3.6'",
-            "numpy==1.15.0; python_version=='3.7'"]
+            "numpy==1.15.0; python_version=='3.7'",
+            "numpy==1.17.3; python_version=='3.8'"]


### PR DESCRIPTION
hi @dmuellner, this change is required for smooth installation of fastcluster under python 3.8.

if acceptable, I'd appreciate if you cut a new release for pypi